### PR TITLE
Remove space in the end of line.

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -45,7 +45,7 @@ class logentries::dependencies (
       }
 
       yumrepo { 'logentries':
-        descr    => "logentries $::operatingsystemrelease $::architecture Repository ",
+        descr    => "logentries $::operatingsystemrelease $::architecture Repository",
         enabled  => 1,
         baseurl  => $::operatingsystem ? {
           /(?i)(fedora|redhat|centos|scientific)/ => 'http://rep.logentries.com/rh/$basearch',


### PR DESCRIPTION
Getting following after running puppet each time. This space in the end of the file makes a diff to puppet but actual file is not changed.

```
Notice: /Stage[main]/Logentries::Dependencies/Yumrepo[logentries]/descr: current_value 'logentries 7.6.1810 x86_64 Repository', should be 'logentries 7.6.1810 x86_64 Repository ' (noop)
Notice: Class[Logentries::Dependencies]: Would have triggered 'refresh' from 1 event
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 10.46 seconds
```