### PR TITLE
Update external fact to check for the executable

### DIFF
--- a/facts.d/tokens.sh
+++ b/facts.d/tokens.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-le2 tokens
-
+if [ -f /usr/bin/le2 ]; then
+  /usr/bin/le2 tokens
+fi


### PR DESCRIPTION
We get following error in dev and custom environments most of the time. That is because everytime when we run puppet, puppet will try to generate facts before it runs puppet code. 

```
error while processing "/opt/puppetlabs/puppet/cache/facts.d/tokens.sh" for external facts: child process returned non-zero exit status (3).
```

We only enable `gns_profile::base::logging::enable: true` in `staging` and in `production. Therefore, puppet will not install logentries packages and scripts. 

```
class gns_profile::base::logging (
  Boolean $enable,
) {

  if $gns_profile::base::logging::enable {
    include logentries

    $log_files = lookup({ 'name' => 'log_files', 'default_value' => {} })

    create_resources('logentries::follow', $log_files)
  }
}
```

Since the script that generate logentries token as a fact is not there its giving a `127` error in the bash script. This change will avoid returning an error and will not pass any value if we are not using logentries in any host.