### PR TITLE
Add capability to set a manual token

### DIFF
--- a/facts.d/tokens.sh
+++ b/facts.d/tokens.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
-if [ -f /usr/bin/le2 ]; then
-  /usr/bin/le2 tokens
+if [ -s /usr/bin/le2 ]; then
+  if [ -s /etc/le/token ]; then
+    # Use /etc/le/token file to manually set a logentries token
+    # and its content should be like this
+    # le_rsyslog_token=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
+    cat /etc/le/token
+  else
+    /usr/bin/le2 tokens
+  fi
 fi


### PR DESCRIPTION
With this change we can set a token manually in hosts so that facts can populate it without calling the `le2` all the time.

Also not going to over complicate things by automatically creating the token file. If the `el2` token generation is not working someone need to create `/etc/le/token` and add the token properly.